### PR TITLE
Adapt docker image build for new repository

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -67,8 +67,8 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
             ls1tum/athena_${{ matrix.image }}
           tags: |
-            type=raw,value=${{ github.ref == format('refs/heads/{0}', 'develop') && 'latest' || 'default-tag' }}
-            type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'default-pr-tag' }}
+            type=raw,value=${{ github.ref == 'refs/heads/develop' && 'latest' || github.sha }}
+            type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
-            ls1intum/Athena/${{ matrix.image }}
+            ls1tum/Athena/${{ matrix.image }}
           tags: |
             type=raw,value=${{ github.ref == format('refs/heads/{0}', 'develop') && 'latest' || 'default-tag' }}
             type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'default-pr-tag' }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
-            ls1tum/Athena/${{ matrix.image }}
+            ls1tum/athena_${{ matrix.image }}
           tags: |
             type=raw,value=${{ github.ref == format('refs/heads/{0}', 'develop') && 'latest' || 'default-tag' }}
             type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'default-pr-tag' }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -47,6 +47,11 @@ jobs:
           docker build -t athena .
           cd ..
 
+      - name: Docker Login
+        id: docker-login
+        run: |
+          docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -58,7 +63,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
+          images: |
+            ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
+            ls1intum/Athena/${{ matrix.image }}
           tags: |
             type=raw,value=${{ github.ref == format('refs/heads/{0}', 'develop') && 'latest' || 'default-tag' }}
             type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'default-pr-tag' }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -58,7 +58,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository_owner }}/athena_${{ matrix.image }}
+          images: ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
         tags: |
           # set latest tag for develop branch
           type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -59,11 +59,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/Athena/${{ matrix.image }}
-        tags: |
-          # set latest tag for develop branch
-          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
-          # set pr-<number> tag for pull requests
-          type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
+          tags: |
+            type=raw,value=${{ github.ref == format('refs/heads/{0}', 'develop') && 'latest' || 'default-tag' }}
+            type=raw,value=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'default-pr-tag' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
-      url: "https://pal03377.github.io/Athena-New"  # TODO: change
+      url: "https://ls1intum.github.io/Athena"
     runs-on: ubuntu-latest
     needs: docs
     steps:

--- a/assessment_module_manager/Dockerfile
+++ b/assessment_module_manager/Dockerfile
@@ -3,7 +3,7 @@
 # This is the Dockerfile for the assessment module manager.
 
 FROM python:3.11
-LABEL org.opencontainers.image.source=https://github.com/pal03377/Athena-New
+LABEL org.opencontainers.image.source=https://github.com/ls1intum/Athena
 
 # Environment variable Python in Docker
 ENV PYTHONUNBUFFERED=1

--- a/docker-compose.playground.prod.yml
+++ b/docker-compose.playground.prod.yml
@@ -7,4 +7,4 @@ services:
 
   playground:
     hostname: playground
-    image: ghcr.io/pal03377/athena_playground:latest
+    image: ghcr.io/ls1intum/Athena/athena_playground:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,29 +17,29 @@ services:
   assessment_module_manager:
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/assessment_module_manager.env
-    image: ghcr.io/pal03377/athena_assessment_module_manager:latest
+    image: ghcr.io/ls1intum/Athena/assessment_module_manager:latest
 
   module_example:
     hostname: module_example
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_example.env
-    image: ghcr.io/pal03377/athena_module_example:latest
+    image: ghcr.io/ls1intum/Athena/module_example:latest
 
   module_programming_llm:
     hostname: module_programming_llm
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_programming_llm.env
-    image: ghcr.io/pal03377/athena_module_programming_llm:latest
+    image: ghcr.io/ls1intum/Athena/module_programming_llm:latest
 
   module_text_llm:
     hostname: module_text_llm
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_text_llm.env
-    image: ghcr.io/pal03377/athena_module_text_llm:latest
+    image: ghcr.io/ls1intum/Athena/module_text_llm:latest
 
   module_text_cofee:
     hostname: module_text_cofee
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_text_cofee.env
-    image: ghcr.io/pal03377/athena_module_text_cofee:latest
+    image: ghcr.io/ls1intum/Athena/module_text_cofee:latest
 

--- a/module_example/Dockerfile
+++ b/module_example/Dockerfile
@@ -3,7 +3,7 @@
 # This is the Dockerfile for the module_example.
 
 FROM python:3.11
-LABEL org.opencontainers.image.source=https://github.com/pal03377/Athena-New
+LABEL org.opencontainers.image.source=https://github.com/ls1intum/Athena
 
 # Environment variable Python in Docker
 ENV PYTHONUNBUFFERED=1

--- a/module_programming_llm/Dockerfile
+++ b/module_programming_llm/Dockerfile
@@ -3,7 +3,7 @@
 # This is the Dockerfile for the assessment module manager.
 
 FROM python:3.11
-LABEL org.opencontainers.image.source=https://github.com/pal03377/Athena-New
+LABEL org.opencontainers.image.source=https://github.com/ls1intum/Athena
 
 # Environment variable Python in Docker
 ENV PYTHONUNBUFFERED=1

--- a/module_text_cofee/Dockerfile
+++ b/module_text_cofee/Dockerfile
@@ -11,7 +11,7 @@ RUN protoc --python_out . cofee.proto
 
 
 FROM python:3.11
-LABEL org.opencontainers.image.source=https://github.com/pal03377/Athena-New
+LABEL org.opencontainers.image.source=https://github.com/ls1intum/Athena
 
 # Environment variable Python in Docker
 ENV PYTHONUNBUFFERED=1

--- a/module_text_llm/Dockerfile
+++ b/module_text_llm/Dockerfile
@@ -3,7 +3,7 @@
 # This is the Dockerfile for the assessment module manager.
 
 FROM python:3.11
-LABEL org.opencontainers.image.source=https://github.com/pal03377/Athena-New
+LABEL org.opencontainers.image.source=https://github.com/ls1intum/Athena
 
 # Environment variable Python in Docker
 ENV PYTHONUNBUFFERED=1

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM node:18.16.0-alpine
 
-LABEL org.opencontainers.image.source=https://github.com/pal03377/Athena-New
+LABEL org.opencontainers.image.source=https://github.com/ls1intum/Athena
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR changes all links to the old location of this repository (https://github.com/pal03377/Athena-New) to the new one (https://github.com/ls1intum/Athena). It also fixes a small configuration error in the docker-images GitHub action.

That way, the docker images are built and published as packages to the GitHub registry (https://github.com/orgs/ls1intum/packages?repo_name=Athena).

They automatically get assigned a tag of `pr-<number>` when built from a PR.