### PR TITLE
Redirect root route to playground

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,6 +2,7 @@
 	email paul.schwind@tum.de
 }
 {$ATHENA_DOMAIN} {
+	redir / /playground 302
 	reverse_proxy /playground* http://playground:3000
 	reverse_proxy http://assessment_module_manager:5000
 }


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When directly visiting the Athena test server URL (e.g. by clicking the "View deployment" button in GitHub) or by just entering the URL normally, you get a 404 error. This is not so helpful. Therefore, we want to redirect to the only page with an actual UI: The playground.
![screenshot-2023-07-04_001486](https://github.com/ls1intum/Athena/assets/9006596/ee46931b-76bf-4aa9-9fe8-f33a6e434e7a)

### Description
<!-- Describe your changes in detail -->
This PR adds a temporary redirect from `/` to `/playground`. This way, we can later change the root without problems if needed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
- Deploy this PR
- Go to https://athenetest1-03.ase.cit.tum.de/
- Verify the redirect to the playground.