### PR TITLE
Show 422 errors in the log

### DIFF
--- a/assessment_module_manager/assessment_module_manager/app.py
+++ b/assessment_module_manager/assessment_module_manager/app.py
@@ -1,4 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .logger import logger
 
 description = """
 This is the Athena API. You are interacting with the Assessment Module Manager, 
@@ -15,3 +19,11 @@ app = FastAPI(
     description=description,
     version="0.1.0"
 )
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    logger.error("Validation error: %s \n Errors: %s\n Request body: %s", exc, exc.errors(), exc.body)
+    return JSONResponse(
+        status_code=422,
+        content={"detail": exc.errors()},
+    )

--- a/athena/athena/app.py
+++ b/athena/athena/app.py
@@ -4,7 +4,9 @@ Instead, use the decorators in the `athena` package.
 The only exception is the `start` method, which is used to start the module.
 """
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from . import env
 from .database import create_tables
@@ -49,3 +51,11 @@ class FastAPIWithStart(FastAPI):
 
 
 app: FastAPIWithStart = FastAPIWithStart()
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    logger.error("Validation error: %s \n Errors: %s\n Request body: %s", exc, exc.errors(), exc.body)
+    return JSONResponse(
+        status_code=422,
+        content={"detail": exc.errors()},
+    )


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When there are problems with the format in which Artemis sends data to Athena, it's hard to debug the problem.

### Description
<!-- Describe your changes in detail -->
Show details on 422 errors in the logs. This way, we can see what's wrong with the sent format.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
- Run the `assessment_module_manager` and the `module_example` locally.
- Run the following commands:
```
# Assessment Module Manager
curl http://localhost:5000/modules/programming/module_example/submissions --data-raw wrong
# Example Module
curl http://localhost:5001/submissions --data-raw wrong
```
- Check that both servers show the 422 problem in the logs.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
<img width="1487" alt="screenshot-2023-07-24_001678" src="https://github.com/ls1intum/Athena/assets/9006596/74cf6e4d-70b1-43e0-8f7d-a06491824bc9">
<img width="950" alt="screenshot-2023-07-24_001679" src="https://github.com/ls1intum/Athena/assets/9006596/d3067fbe-8701-4dcc-bb3c-8e590a4ca8a4">
