### PR TITLE
Make feedback description optional

### DIFF
--- a/athena/athena/models/db_feedback.py
+++ b/athena/athena/models/db_feedback.py
@@ -9,7 +9,7 @@ class DBFeedback(Model):
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     lms_id = Column(Integer)
     title = Column(String)
-    description = Column(String, nullable=False)
+    description = Column(String)
     credits = Column(Float, nullable=False)
     grading_instruction_id = Column(Integer)
     meta = Column(JSON, nullable=False)

--- a/athena/athena/schemas/feedback.py
+++ b/athena/athena/schemas/feedback.py
@@ -10,7 +10,7 @@ class Feedback(Schema, ABC):
     id: Optional[int] = Field(None, example=1)
     title: Optional[str] = Field(None, description="The title of the feedback that is shown to the student.", 
                       example="File src/pe1/MergeSort.java at line 12")
-    description: str = Field("", description="The detailed feedback description that is shown to the student.",
+    description: Optional[str] = Field(None, description="The detailed feedback description that is shown to the student.",
                              example="Your solution is correct.")
     credits: float = Field(0.0, description="The number of points that the student received for this feedback.",
                            example=1.0)

--- a/module_programming_llm/module_programming_llm/basic/basic_feedback_provider.py
+++ b/module_programming_llm/module_programming_llm/basic/basic_feedback_provider.py
@@ -90,7 +90,7 @@ async def suggest_feedback(exercise: Exercise, submission: Submission) -> List[F
 
             for feedback in feedbacks:
                 line = feedback.get("line", None)
-                description = feedback.get("text", "")
+                description = feedback.get("text", None)
                 credits = feedback.get("credits", 0.0)
                 feedback_proposals.append(
                     Feedback(

--- a/playground/src/model/feedback.ts
+++ b/playground/src/model/feedback.ts
@@ -1,7 +1,7 @@
 type FeedbackBase = {
   id: number;
-  title: string;
-  description: string;
+  title?: string;
+  description?: string;
   credits: number;
   exercise_id: number;
   submission_id: number;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When we tested https://github.com/ls1intum/Artemis/pull/6861 in a testing session, we found an issue where you could get an HTTP error 422 from Athena. According to @Strohgelaender, you can provoke this only as an instructor because then, some checks for feedback are disabled. We should prevent these kinds of issues, even if they only happen for instructors.

### Description
<!-- Describe your changes in detail -->
Make the `description` field on feedback optional.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
- Test feedback sending using the playground
- Maybe test sending feedback with no description