### PR TITLE
Find specific Docker tag for build

### DIFF
--- a/.github/scripts/images-to-build.sh
+++ b/.github/scripts/images-to-build.sh
@@ -57,20 +57,24 @@ for DIR in */; do
         fi
 
         # Construct Docker image name and tag
-        IMAGE_NAME="athena%2F$DIR"
+        IMAGE_NAME="athena/$DIR"
         IMAGE_TAG="pr-$PR_NUMBER"
 
         # Check if any file has changed in that directory since the pull request was created
         IS_CHANGED=$(echo "$CHANGED_FILES" | grep -q "^$DIR" && echo "true" || echo "false")
         # Check if Docker image exists on GitHub Packages
-        URL="https://api.github.com/orgs/$ORGANIZATION_NAME/packages/container/$IMAGE_NAME"
         RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -L \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
-        https://api.github.com/orgs/$ORGANIZATION_NAME/packages/container/$IMAGE_NAME)
+        https://ghcr.io/v2/$ORGANIZATION_NAME/$IMAGE_NAME/tags/list)
         # Check if the image exists
         if [ $RESPONSE -eq 200 ]; then
-            IMAGE_EXISTS=true
+            # find the string "pr-<n>" in the response (with quotes)
+            if [[ $RESPONSE == *"\"$IMAGE_TAG\""* ]]; then
+                IMAGE_EXISTS=true
+            else
+                IMAGE_EXISTS=false
+            fi
         else
             IMAGE_EXISTS=false
         fi

--- a/.github/scripts/images-to-build.sh
+++ b/.github/scripts/images-to-build.sh
@@ -65,7 +65,7 @@ for DIR in */; do
         # Check if Docker image exists on GitHub Packages
         RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -L \
         -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Authorization: Bearer $(echo $GITHUB_TOKEN | base64)" \
         https://ghcr.io/v2/$ORGANIZATION_NAME/$IMAGE_NAME/tags/list)
         # Check if the image exists
         if [ $RESPONSE -eq 200 ]; then


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#73 has issues where the necessary docker images are not built, even though they don't exist yet.

### Description
<!-- Describe your changes in detail -->
Solution: Properly detect if the images already exist or not. Before, the tag wasn't taken into consideration by accident. Now, the specific tag of the Docker image is checked in GitHub.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Note that the build step to find images to build correctly identifies the image as missing: https://github.com/ls1intum/Athena/actions/runs/5849504932/job/15857908702?pr=74#step:3:45

Also, note that merging the branch of this PR into #73 fixes the issue there: All missing images are now built: https://github.com/ls1intum/Athena/actions/runs/5849540999/job/15857980555
(you can also check that the deployment now works correctly)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
![screenshot-2023-08-13_001780](https://github.com/ls1intum/Athena/assets/9006596/fc8d34a9-1b61-485e-9228-66fb12f45c82)
