### PR TITLE
Quickfix: Change default db url

### DIFF
--- a/env_example/module_example.env
+++ b/env_example/module_example.env
@@ -1,3 +1,3 @@
 PRODUCTION=1
 SECRET=12345abcdef
-DATABASE_URL=sqlite:///../data/data.sqlite
+DATABASE_URL=postgresql://postgres:password@postgres:5432/athena

--- a/env_example/module_programming_llm.env
+++ b/env_example/module_programming_llm.env
@@ -1,6 +1,6 @@
 PRODUCTION=1
 SECRET=12345abcdef
-DATABASE_URL=sqlite:///../data/data.sqlite
+DATABASE_URL=postgresql://postgres:password@postgres:5432/athena
 
 OPENAI_API_KEY="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 

--- a/env_example/module_programming_themisml.env
+++ b/env_example/module_programming_themisml.env
@@ -1,3 +1,3 @@
 PRODUCTION=1
 SECRET=12345abcdef
-DATABASE_URL=sqlite:///../data/data.sqlite
+DATABASE_URL=postgresql://postgres:password@postgres:5432/athena

--- a/env_example/module_text_cofee.env
+++ b/env_example/module_text_cofee.env
@@ -1,6 +1,6 @@
 PRODUCTION=1
 SECRET=12345abcdef
-DATABASE_URL=sqlite:///../data/data.sqlite
+DATABASE_URL=postgresql://postgres:password@postgres:5432/athena
 
 # CoFee-specific variables
 # URL of the CoFee system by Jan Philip Bernius

--- a/env_example/module_text_llm.env
+++ b/env_example/module_text_llm.env
@@ -1,6 +1,6 @@
 PRODUCTION=1
 SECRET=12345abcdef
-DATABASE_URL=sqlite:///../data/data.sqlite
+DATABASE_URL=postgresql://postgres:password@postgres:5432/athena
 
 
 ################################################################


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The default DB URLs don't use postgres. Because of this, a simple production setup only with Docker did not work

### Description
<!-- Describe your changes in detail -->
Use postgres by default

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->