### PR TITLE
Fix: Allow ID autoincrement in SQLite

### DIFF
--- a/athena/athena/models/big_integer_with_autoincrement.py
+++ b/athena/athena/models/big_integer_with_autoincrement.py
@@ -1,0 +1,16 @@
+"""
+SQLAlchemy + SQLite does not support the autoincrement feature for BigInteger columns.
+This file provides a class as a workaround for this problem:
+It uses a normal Integer column in SQLite and a BigInteger column otherwise.
+SQLite Integer columns can autoincrement, but they are limited to 2^63-1.
+See https://stackoverflow.com/a/23175518/4306257 for more information.
+"""
+
+from sqlalchemy import BigInteger
+from sqlalchemy.dialects import postgresql, mysql, sqlite
+
+# Solution from https://stackoverflow.com/a/23175518/4306257
+BigIntegerWithAutoincrement = BigInteger()
+BigIntegerWithAutoincrement = BigIntegerWithAutoincrement.with_variant(postgresql.BIGINT(), 'postgresql')
+BigIntegerWithAutoincrement = BigIntegerWithAutoincrement.with_variant(mysql.BIGINT(), 'mysql')
+BigIntegerWithAutoincrement = BigIntegerWithAutoincrement.with_variant(sqlite.INTEGER(), 'sqlite')

--- a/athena/athena/models/db_exercise.py
+++ b/athena/athena/models/db_exercise.py
@@ -1,11 +1,12 @@
-from sqlalchemy import Column, BigInteger, String, Float, JSON, Enum as SqlEnum
+from sqlalchemy import Column, String, Float, JSON, Enum as SqlEnum
 
 from athena.schemas import ExerciseType
 from .model import Model
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBExercise(Model):
-    id = Column(BigInteger, primary_key=True, index=True, nullable=False)
+    id = Column(BigIntegerWithAutoincrement, primary_key=True, index=True, nullable=False)
     title = Column(String, index=True, nullable=False)
     type = Column(SqlEnum(ExerciseType), index=True, nullable=False)
     max_points = Column(Float, index=True, nullable=False)

--- a/athena/athena/models/db_feedback.py
+++ b/athena/athena/models/db_feedback.py
@@ -1,12 +1,13 @@
 from sqlalchemy import Column, BigInteger, Boolean, String, Float, JSON, UniqueConstraint
 
 from .model import Model
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBFeedback(Model):
     __table_args__ = (UniqueConstraint('lms_id'),)
 
-    id = Column(BigInteger, primary_key=True, index=True, autoincrement=True)
+    id = Column(BigIntegerWithAutoincrement, primary_key=True, index=True, autoincrement=True)
     lms_id = Column(BigInteger)
     title = Column(String)
     description = Column(String)

--- a/athena/athena/models/db_programming_feedback.py
+++ b/athena/athena/models/db_programming_feedback.py
@@ -1,11 +1,12 @@
 from typing import cast, Optional
 from athena.schemas.programming_submission import ProgrammingSubmission
-from sqlalchemy import Column, Integer, BigInteger, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
 
 from athena.database import Base, get_db
 from .db_programming_submission import DBProgrammingSubmission
 from .db_feedback import DBFeedback
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBProgrammingFeedback(DBFeedback, Base):
@@ -15,8 +16,8 @@ class DBProgrammingFeedback(DBFeedback, Base):
     line_start: Optional[int] = Column(Integer)  # type: ignore
     line_end: Optional[int] = Column(Integer)  # type: ignore
 
-    exercise_id = Column(BigInteger, ForeignKey("programming_exercises.id", ondelete="CASCADE"), index=True)
-    submission_id = Column(BigInteger, ForeignKey("programming_submissions.id", ondelete="CASCADE"), index=True)
+    exercise_id = Column(BigIntegerWithAutoincrement, ForeignKey("programming_exercises.id", ondelete="CASCADE"), index=True)
+    submission_id = Column(BigIntegerWithAutoincrement, ForeignKey("programming_submissions.id", ondelete="CASCADE"), index=True)
 
     exercise = relationship("DBProgrammingExercise", back_populates="feedbacks")
     submission = relationship("DBProgrammingSubmission", back_populates="feedbacks")

--- a/athena/athena/models/db_programming_submission.py
+++ b/athena/athena/models/db_programming_submission.py
@@ -1,15 +1,16 @@
-from sqlalchemy import ForeignKey, BigInteger, Column, String
+from sqlalchemy import ForeignKey, Column, String
 from sqlalchemy.orm import relationship
 
 from athena.database import Base
 from .db_submission import DBSubmission
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBProgrammingSubmission(DBSubmission, Base):
     __tablename__ = "programming_submissions"
     repository_url: str = Column(String, nullable=False)  # type: ignore
 
-    exercise_id = Column(BigInteger, ForeignKey("programming_exercises.id", ondelete="CASCADE"), index=True)
+    exercise_id = Column(BigIntegerWithAutoincrement, ForeignKey("programming_exercises.id", ondelete="CASCADE"), index=True)
 
     exercise = relationship("DBProgrammingExercise", back_populates="submissions")
     feedbacks = relationship("DBProgrammingFeedback", back_populates="submission")

--- a/athena/athena/models/db_submission.py
+++ b/athena/athena/models/db_submission.py
@@ -1,7 +1,9 @@
-from sqlalchemy import Column, BigInteger, JSON
+from sqlalchemy import Column, JSON
+
 from .model import Model
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBSubmission(Model):
-    id = Column(BigInteger, primary_key=True, index=True, nullable=False)
+    id = Column(BigIntegerWithAutoincrement, primary_key=True, index=True, autoincrement=True,)
     meta = Column(JSON, nullable=False)

--- a/athena/athena/models/db_text_feedback.py
+++ b/athena/athena/models/db_text_feedback.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from sqlalchemy import Column, Integer, BigInteger, ForeignKey
+from sqlalchemy import Column, Integer, ForeignKey
 from sqlalchemy.orm import relationship
 
 from athena.database import Base
 from .db_feedback import DBFeedback
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBTextFeedback(DBFeedback, Base):
@@ -13,8 +14,8 @@ class DBTextFeedback(DBFeedback, Base):
     index_start: Optional[int] = Column(Integer)  # type: ignore
     index_end: Optional[int] = Column(Integer)  # type: ignore
 
-    exercise_id = Column(BigInteger, ForeignKey("text_exercises.id", ondelete="CASCADE"), index=True)
-    submission_id = Column(BigInteger, ForeignKey("text_submissions.id", ondelete="CASCADE"), index=True)
+    exercise_id = Column(BigIntegerWithAutoincrement, ForeignKey("text_exercises.id", ondelete="CASCADE"), index=True)
+    submission_id = Column(BigIntegerWithAutoincrement, ForeignKey("text_submissions.id", ondelete="CASCADE"), index=True)
 
     exercise = relationship("DBTextExercise", back_populates="feedbacks")
     submission = relationship("DBTextSubmission", back_populates="feedbacks")

--- a/athena/athena/models/db_text_submission.py
+++ b/athena/athena/models/db_text_submission.py
@@ -1,8 +1,9 @@
-from sqlalchemy import ForeignKey, BigInteger, Column, String
+from sqlalchemy import ForeignKey, Column, String
 from sqlalchemy.orm import relationship
 
 from athena.database import Base
 from .db_submission import DBSubmission
+from .big_integer_with_autoincrement import BigIntegerWithAutoincrement
 
 
 class DBTextSubmission(DBSubmission, Base):
@@ -10,7 +11,7 @@ class DBTextSubmission(DBSubmission, Base):
     text: str = Column(String, nullable=False)  # type: ignore
     language: str = Column(String, nullable=True)  # type: ignore
 
-    exercise_id = Column(BigInteger, ForeignKey("text_exercises.id", ondelete="CASCADE"), index=True)
+    exercise_id = Column(BigIntegerWithAutoincrement, ForeignKey("text_exercises.id", ondelete="CASCADE"), index=True)
 
     exercise = relationship("DBTextExercise", back_populates="submissions")
     feedbacks = relationship("DBTextFeedback", back_populates="submission")


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Because of #75, storing data into the SQLite database does not work as expected locally anymore: The ID cannot be autoincremented, and therefore the database write fails (error log provided by @FelixTJDietrich):
```
File "/Users/TJ/Projects/Athena/athena/athena/storage/feedback_storage.py", line 74, in store_feedback_suggestions
    db.flush() # Ensure the ID is generated now
    ^^^^^^^^^^
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/session.py", line 4163, in flush
    self._flush(objects)
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/session.py", line 4298, in _flush
    with util.safe_reraise():
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py", line 147, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/session.py", line 4259, in _flush
    flush_context.execute()
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py", line 466, in execute
    rec.execute(self)
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py", line 642, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py", line 93, in save_obj
    _emit_insert_statements(
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py", line 1226, in _emit_insert_statements
    result = connection.execute(
             ^^^^^^^^^^^^^^^^^^^
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1412, in execute
    return meth(
           ^^^^^
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 483, in _execute_on_connection
    return connection._execute_clauseelement(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1635, in _execute_clauseelement
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1844, in _execute_context
    return self._exec_single_context(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1984, in _exec_single_context
    self._handle_dbapi_exception(
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 2339, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1965, in _exec_single_context
    self.dialect.do_execute(
  File "/Users/TJ/Projects/Athena/module_text_llm/.venv/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 921, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) NOT NULL constraint failed: text_feedbacks.id
[SQL: INSERT INTO text_feedbacks (index_start, index_end, exercise_id, submission_id, lms_id, title, description, credits, grading_instruction_id, meta, is_suggestion) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]
[parameters: (0, 146, 4082, 752966, None, 'Explanation of Why Change Occurs', 'Correct explanation, but weak. Please be more specific and explain the reason behind the frequent occurrence of change in software development in more detail.', 1.0, None, '{}', 1)]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
```

### Description
<!-- Describe your changes in detail -->
Add the fix described [here](https://stackoverflow.com/questions/18835740/does-bigint-auto-increment-work-for-sqlalchemy-with-sqlite) to automatically use integers in SQLite.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Remove your local SQlite database
2. Test locally that sending data to all endpoints still works, using the SQLite database.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
-/-