### PR TITLE
Docker Production: Add dependencies on Postgres startup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,18 +17,24 @@ services:
   assessment_module_manager:
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/assessment_module_manager.env
+    depends_on:
+      - postgres
     image: ls1tum/athena_assessment_module_manager:${ATHENA_TAG:-develop}
 
   module_example:
     hostname: module_example
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_example.env
+    depends_on:
+      - postgres
     image: ls1tum/athena_module_example:${ATHENA_TAG:-develop}
 
   module_programming_llm:
     hostname: module_programming_llm
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_programming_llm.env
+    depends_on:
+      - postgres
     image: ls1tum/athena_module_programming_llm:${ATHENA_TAG:-develop}
 
   module_text_llm:
@@ -41,12 +47,16 @@ services:
     hostname: module_text_cofee
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_text_cofee.env
+    depends_on:
+      - postgres
     image: ls1tum/athena_module_text_cofee:${ATHENA_TAG:-develop}
 
   module_programming_themisml:
     hostname: module_programming_themisml
     env_file:
       - ${ATHENA_ENV_DIR:-./env_example}/module_programming_themisml.env
+    depends_on:
+      - postgres
     image: ls1tum/athena_module_programming_themisml:${ATHENA_TAG:-develop}
 
   postgres:


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Sometimes, the PostgreSQL database would not start up quick enough with the production setup and therefore, some modules would crash.

### Description
<!-- Describe your changes in detail -->
Added a dependency in the production docker-compose file to wait for Postgres to start.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Start the production docker compose file, e.g. by deploying to the test server. Alternative for local setup: `docker compose -f docker-compose.prod.yml up --pull`