### PR TITLE
Allow Problem Statement to be null / None

### DIFF
--- a/athena/athena/models/db_exercise.py
+++ b/athena/athena/models/db_exercise.py
@@ -12,5 +12,5 @@ class DBExercise(Model):
     max_points = Column(Float, index=True, nullable=False)
     bonus_points = Column(Float, index=True, nullable=False)
     grading_instructions = Column(String)
-    problem_statement = Column(String, nullable=False)
+    problem_statement = Column(String)
     meta = Column(JSON, nullable=False)

--- a/athena/athena/schemas/exercise.py
+++ b/athena/athena/schemas/exercise.py
@@ -21,7 +21,7 @@ class Exercise(Schema, ABC):
                                 example=0.0)
     grading_instructions: Optional[str] = Field(None, description="Markdown text that describes how the exercise is graded.",
                                       example="Give 1 point for each correct answer.")
-    problem_statement: str = Field("", description="Markdown text that describes the problem statement.",
+    problem_statement: Optional[str] = Field(None, description="Markdown text that describes the problem statement.",
                                    example="Write a program that prints 'Hello World!'")
 
     meta: dict = Field({}, example={"internal_id": "5"})

--- a/module_programming_llm/module_programming_llm/basic/file_instructions.py
+++ b/module_programming_llm/module_programming_llm/basic/file_instructions.py
@@ -39,7 +39,7 @@ def generate_file_grading_instructions(exercise: Exercise):
 
 
 def generate_file_problem_statements(exercise: Exercise):
-    problem_statement = exercise.problem_statement
+    problem_statement = exercise.problem_statement or ""
 
     solution_repo = exercise.get_solution_repository()
     template_repo = exercise.get_template_repository()

--- a/module_text_llm/module_text_llm/suggest_feedback_basic.py
+++ b/module_text_llm/module_text_llm/suggest_feedback_basic.py
@@ -24,7 +24,7 @@ async def suggest_feedback_basic(exercise: Exercise, submission: Submission, con
         "max_points": exercise.max_points,
         "bonus_points": exercise.bonus_points,
         "grading_instructions": exercise.grading_instructions,
-        "problem_statement": exercise.problem_statement,
+        "problem_statement": exercise.problem_statement or "",
         # TODO: "example_solution": exercise.example_solution, MISSING
         "submission": add_sentence_numbers(submission.text)
     }

--- a/playground/src/components/details/exercise_detail/common.tsx
+++ b/playground/src/components/details/exercise_detail/common.tsx
@@ -11,9 +11,9 @@ export default function CommonExerciseDetail({ exercise, openedInitially }: { ex
       </div>
       {/* Problem Statement */}
       <Disclosure title="Problem Statement" openedInitially={openedInitially}>
-        {exercise.problem_statement.length > 0 ? (
+        {exercise.problem_statement ? (
           <Markdown
-            content={exercise.problem_statement}
+            content={exercise.problem_statement ?? ""}
             enablePlainTextSwitcher
           />
         ) : (

--- a/playground/src/model/exercise.ts
+++ b/playground/src/model/exercise.ts
@@ -8,7 +8,7 @@ type ExerciseBase = {
   max_points: number;
   bonus_points: number;
   grading_instructions?: string;
-  problem_statement: string;
+  problem_statement?: string;
   meta: {
     [key: string]: any;
   };


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When you don't enter a problem statement for a new text exercise, its value is `null`. This crashes Athena.

### Description
<!-- Describe your changes in detail -->
We solve this by allowing the problem statement to be `None` in Athena.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Create a new text exercise on https://ma-schwind.ase.cit.tum.de/. Leave the problem statement empty. Enable automatic assessment. Then, set the due date to something in the future. Athena should not reject the submissions anymore.
