### PR TITLE
Run consumers asynchronously

### DIFF
--- a/athena/athena/endpoints.py
+++ b/athena/athena/endpoints.py
@@ -71,10 +71,10 @@ def submissions_consumer(func: Union[
     @authenticated
     @with_meta
     async def wrapper(
+            background_tasks: BackgroundTasks,
             exercise: exercise_type,
             submissions: List[submission_type],
-            module_config: module_config_type = Depends(get_dynamic_module_config_factory(module_config_type)),
-            background_tasks: BackgroundTasks = Depends()):
+            module_config: module_config_type = Depends(get_dynamic_module_config_factory(module_config_type))):
         
         # Retrieve existing metadata for the exercise and submissions
         exercise_meta = get_stored_exercise_meta(exercise) or {}
@@ -239,11 +239,11 @@ def feedback_consumer(func: Union[
     @authenticated
     @with_meta
     async def wrapper(
+            background_tasks: BackgroundTasks,
             exercise: exercise_type,
             submission: submission_type,
             feedbacks: List[feedback_type],
-            module_config: module_config_type = Depends(get_dynamic_module_config_factory(module_config_type)),
-            background_tasks: BackgroundTasks = Depends()):
+            module_config: module_config_type = Depends(get_dynamic_module_config_factory(module_config_type))):
 
         # Retrieve existing metadata for the exercise, submission and feedback
         exercise.meta.update(get_stored_exercise_meta(exercise) or {})


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Sometimes, requests from Artemis for submission sending would time out after 10 seconds because Athena did not answer in time. Athena does not respond with any "real" information, so the response could and should be immediate.

### Description
<!-- Describe your changes in detail -->
For the consumer endpoints (which don't return anything), we now run the actual computation from the module asynchronously in the background.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Test the consumers by sending submissions / feedback to Athena. They should respond pretty quickly now.