### PR TITLE
Allow nullable example solution in text exercises

### DIFF
--- a/athena/athena/models/db_text_exercise.py
+++ b/athena/athena/models/db_text_exercise.py
@@ -8,7 +8,7 @@ from .db_exercise import DBExercise
 class DBTextExercise(DBExercise, Base):
     __tablename__ = "text_exercises"
 
-    example_solution: str = Column(String, nullable=False)  # type: ignore
+    example_solution: str = Column(String)  # type: ignore
 
     submissions = relationship("DBTextSubmission", back_populates="exercise")
     feedbacks = relationship("DBTextFeedback", back_populates="exercise")

--- a/athena/athena/schemas/text_exercise.py
+++ b/athena/athena/schemas/text_exercise.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import Field
 
 from .exercise_type import ExerciseType
@@ -9,4 +10,4 @@ class TextExercise(Exercise):
 
     type: ExerciseType = Field(ExerciseType.text, const=True)
 
-    example_solution: str = Field("", description="An example solution to the exercise.")
+    example_solution: Optional[str] = Field(None, description="An example solution to the exercise.")


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some text exercises error because they don't have an example solution. For example id: `4279`

### Description
<!-- Describe your changes in detail -->

Allows None for the `example_solution` in text exercises.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Delete db
2. Run text module + assessment_module_manager
3. Use playground with exported evaluation data 
4. Request a suggestion with a text module for exercise `4279`

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

<img width="1328" alt="image" src="https://github.com/ls1intum/Athena/assets/5898705/fadb13eb-9c7c-4b93-8ad6-c582bccdadee">
