### PR TITLE
Fix long module config loading state

### DIFF
--- a/playground/src/components/selectors/module_and_config_select.tsx
+++ b/playground/src/components/selectors/module_and_config_select.tsx
@@ -24,7 +24,7 @@ function ModuleConfig({
   showOverrideCheckbox,
   collapsibleConfig,
 }: ModuleConfigProps) {
-  const { data, error, isLoading } = useConfigSchema();
+  const { data, error, isLoading } = useConfigSchema({ retry: false });
 
   return (
     <div className="mt-2 space-y-1">
@@ -32,7 +32,7 @@ function ModuleConfig({
       {error &&
         (error.status === 404 ? (
           <p className="text-gray-500">
-            Config options not available, not implemented in the module
+            Config options not available, not implemented for this module
           </p>
         ) : (
           <p className="text-red-500">


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The module config shows `Loading...` for a long time when it is not implemented by the module.

### Description
<!-- Describe your changes in detail -->

Disable retrying when config loading fails.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. `module_programming_llm` can be used for testing in the playground
2. Select module in the module requests
3. It should now show `Config options not available, not implemented for this module` much faster.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

<img width="1338" alt="image" src="https://github.com/ls1intum/Athena/assets/5898705/a86da4b0-8e8d-47f5-85fe-a621079a4c93">

