### PR TITLE
Indicate grading instruction with badge

### DIFF
--- a/playground/src/components/details/editor/inline_feedback.tsx
+++ b/playground/src/components/details/editor/inline_feedback.tsx
@@ -193,11 +193,18 @@ export default function InlineFeedback({
                 {feedback.title ? feedback.title : <i>Missing title</i>}
               </span>
             )}
-            {feedback.isSuggestion && (
-              <span className="text-xs text-violet-800 rounded-full px-2 py-0.5 bg-violet-100">
-                Suggestion
-              </span>
-            )}
+            <div className="flex gap-1">
+              {feedback.isSuggestion && (
+                <span className="text-xs text-violet-800 rounded-full px-2 py-0.5 bg-violet-100">
+                  Suggestion
+                </span>
+              )}
+              {feedback.grading_instruction_id && (
+                <span className="text-xs text-orange-800 rounded-full px-2 py-0.5 bg-orange-100">
+                  Grading Instruction
+                </span>
+              )}
+            </div>
           </div>
           <div>
             {isEditing && onFeedbackChange ? (

--- a/playground/src/model/feedback.ts
+++ b/playground/src/model/feedback.ts
@@ -10,6 +10,7 @@ type FeedbackBase = {
   credits: number;
   exercise_id: number;
   submission_id: number;
+  grading_instruction_id?: number;
   isSuggestion?: boolean; // Playground only
   isNew?: boolean; // Playground only
   isChanged?: boolean; // Playground only


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

@maximiliansoelch pointed out that it is a bit hard to understand that feedback with a proper title are indeed gradin instructions.

### Description
<!-- Describe your changes in detail -->

Add a grading instruction badge that shows when a feedback has a `grading_instruction_id`.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Use evaluation data or change example data to include a `grading_instrustion_id` in the feedback
2. Preview the feedback in the playground (for instance through `send feedback to Athena`)
3. Verify that the badge is there

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

<img width="784" alt="image" src="https://github.com/ls1intum/Athena/assets/5898705/77ec18c6-446e-4d60-84ff-777a5c7a2a05">
