### PR TITLE
Fix Docker login (and Test Server Deployment)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Docker meta
         id: meta


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Docker image upload currently [does not work](https://github.com/ls1intum/Athena/actions/runs/6462491466/job/17544195812?pr=125). This also breaks test server deployments.

### Description
<!-- Describe your changes in detail -->
Update the way we authenticate against GitHub's package registry using another token, following https://github.com/docker/login-action#github-container-registry

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Test the Docker image build & upload.