### PR TITLE
Remove all unused images on cleanup, not just dangling ones

### DIFF
--- a/athena-docker.sh
+++ b/athena-docker.sh
@@ -101,7 +101,7 @@ function all_logs {
 }
 
 function cleanup {
-  docker image prune -f
+  docker image prune -a -f # remove all unused images
 }
 
 function run_docker_compose_cmd {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The test server disk space got full because non-dangling Docker images were not removed.

### Description
<!-- Describe your changes in detail -->
Change the existing Docker cleanup (after TS deployment) to also remove non-dangling images.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Deploy to the test server. Then, observe how old images are removed and there won't be a disk space problem for a longer time span.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
I manually executed the cleanup command to test:
![screenshot-2023-10-22_002031](https://github.com/ls1intum/Athena/assets/9006596/1e888d52-e471-4f6f-b944-35cfa5d986bd)
