### PR TITLE
Trigger GitHub Actions for any branch target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - develop
   pull_request:
-    branches:
-      - develop
 
 # prevent Docker image push conflicts
 concurrency: 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - develop
   pull_request:
-    branches:
-      - develop
 
 jobs:
   prospector:


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The build didn't work for #125.

The problem was that the target branch was not `develop`. Because of misconfiguration of the GitHub Action, the build did not run.

### Description
<!-- Describe your changes in detail -->
Change configuration to also trigger CI builds with targets other than `develop`. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[Merge](https://github.com/ls1intum/Athena/pull/125/commits/dee894dc51fa1cd6e8247a11ac5e700b7a2e6fee) this PR into #125 and see [that it builds](https://github.com/ls1intum/Athena/actions/runs/6625537428/job/17996700870), even with a target branch other than `develop`.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
![screenshot-2023-10-24_002037](https://github.com/ls1intum/Athena/assets/9006596/960535a5-3162-4a5e-ba07-39277d4c9ec3)
