### PR TITLE
Add experiment middleware and LLM call tags for logging

### DIFF
--- a/assessment_module_manager/assessment_module_manager/endpoints/modules_proxy_endpoint.py
+++ b/assessment_module_manager/assessment_module_manager/endpoints/modules_proxy_endpoint.py
@@ -46,10 +46,28 @@ async def proxy_to_module(
     if module.type != module_type:
         raise HTTPException(status_code=400, detail=f"Found module {module_name} is not of type {module_type}.")
     
+    # Prepare headers (except Authorization)
+    headers = {}
+    
+    # Module configuration
     module_config = request.headers.get('X-Module-Config')
+    if module_config:
+        headers['X-Module-Config'] = module_config
+
+    # Experiment information tracking experiment, module configuration, and run
+    experiment_id = request.headers.get('X-Experiment-ID')
+    if experiment_id:
+        headers['X-Experiment-ID'] = experiment_id
+    module_configuration_id = request.headers.get('X-Module-Configuration-ID')
+    if module_configuration_id:
+        headers['X-Module-Configuration-ID'] = module_configuration_id
+    run_id = request.headers.get('X-Run-ID')
+    if run_id:
+        headers['X-Run-ID'] = run_id
+
     resp = await request_to_module(
         module,
-        module_config,
+        headers,
         '/' + path,
         data,
         method=request.method,

--- a/assessment_module_manager/assessment_module_manager/module/request_to_module.py
+++ b/assessment_module_manager/assessment_module_manager/module/request_to_module.py
@@ -33,17 +33,14 @@ async def find_module_by_name(module_name: str) -> Optional[Module]:
     return None
 
 
-async def request_to_module(module: Module, module_config: Optional[str], path: str, data: Optional[dict], method: str) -> ModuleResponse:
+async def request_to_module(module: Module, headers: dict, path: str, data: Optional[dict], method: str) -> ModuleResponse:
     """
     Helper function to send a request to a module.
     It raises appropriate FastAPI HTTPException if the request fails.
     """
     module_secret = env.MODULE_SECRETS[module.name]
-    headers = {}
     if module_secret:
         headers['Authorization'] = module_secret
-    if module_config:
-        headers['X-Module-Config'] = module_config
 
     if module.type == ExerciseType.programming:
         # We need the Athena secret with the LMS to access repositories.

--- a/athena/athena/__init__.py
+++ b/athena/athena/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from .app import app
 from .schemas import ExerciseType
 from .metadata import emit_meta, get_meta
+from .experiment import get_experiment_environment
 from .endpoints import submission_selector, submissions_consumer, feedback_consumer, feedback_provider, config_schema_provider  # type: ignore
 
 
@@ -29,6 +30,7 @@ __all__ = [
     "config_schema_provider",
     "emit_meta",
     "get_meta",
+    "get_experiment_environment",
     "ExerciseType",
     "app"
 ]

--- a/athena/athena/app.py
+++ b/athena/athena/app.py
@@ -13,6 +13,7 @@ from .database import create_tables
 from .logger import logger
 from .module_config import get_module_config
 from .metadata import MetaDataMiddleware
+from .experiment import ExperimentMiddleware
 from .helpers.programming.repository_authorization_middleware import init_repo_auth_middleware
 
 
@@ -25,6 +26,7 @@ class FastAPIWithStart(FastAPI):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.add_middleware(MetaDataMiddleware)
+        self.add_middleware(ExperimentMiddleware)
 
 
     def start(self) -> None:

--- a/athena/athena/experiment.py
+++ b/athena/athena/experiment.py
@@ -1,0 +1,68 @@
+"""
+Provides the experiment environment for Athena so it knows which experiment is currently running.
+
+Note: This is mainly being used in the Playground during research and development but could also be used in production.
+"""
+
+import contextvars
+from typing import Optional
+
+from fastapi import Request
+from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+
+class ExperimentEnvironment(BaseModel):
+    experiment_id: Optional[str]
+    module_configuration_id: Optional[str]
+    run_id: Optional[str]
+
+
+experiment_context: contextvars.ContextVar[ExperimentEnvironment] = contextvars.ContextVar("experiment")
+
+
+class ExperimentMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to handle the experiment environment in the context of HTTP requests.
+
+    This middleware allows to get the experiment environment context in each HTTP request.
+    The context is then available throughout the processing of a request, even in asynchronous operations.
+    """
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+        """
+        Middleware dispatcher.
+
+        This method sets the experiment environment context at the start of processing each request.
+        It then gets the response from the next middleware or the actual route handler, and returns it.
+
+        Args:
+            request (Request): The incoming HTTP request.
+            call_next (RequestResponseEndpoint): The next middleware or route handler.
+
+        Returns:
+            The response from the next middleware or route handler.
+        """
+        experiment = ExperimentEnvironment(
+            experiment_id=request.headers.get('X-Experiment-ID'), 
+            module_configuration_id=request.headers.get('X-Module-Configuration-ID'),
+            run_id=request.headers.get('X-Run-ID'),
+        )
+
+        experiment_context.set(experiment)
+        response = await call_next(request)
+        return response
+
+
+def get_experiment_environment() -> ExperimentEnvironment:
+    """
+    Get the experiment environment.
+
+    Returns:
+        ExperimentEnvironment: The experiment environment
+    """
+    return experiment_context.get(ExperimentEnvironment(
+            experiment_id=None, 
+            module_configuration_id=None,
+            run_id=None,
+        )
+    )

--- a/module_programming_llm/module_programming_llm/generate_suggestions_by_file.py
+++ b/module_programming_llm/module_programming_llm/generate_suggestions_by_file.py
@@ -202,7 +202,13 @@ async def generate_suggestions_by_file(exercise: Exercise, submission: Submissio
             model=model, 
             chat_prompt=chat_prompt, 
             prompt_input=prompt_input, 
-            pydantic_object=AssessmentModel
+            pydantic_object=AssessmentModel,
+            tags=[
+                f"exercise-{exercise.id}",
+                f"submission-{submission.id}",
+                f"file-{prompt_input['file_path']}",
+                "generate-suggestions-by-file"
+            ]
         ) for prompt_input in prompt_inputs
     ])
 

--- a/module_programming_llm/module_programming_llm/helpers/llm_utils.py
+++ b/module_programming_llm/module_programming_llm/helpers/llm_utils.py
@@ -14,7 +14,7 @@ from langchain.chains.openai_functions import create_structured_output_chain
 from langchain.output_parsers import PydanticOutputParser
 from langchain.schema import OutputParserException
 
-from athena import emit_meta
+from athena import emit_meta, get_experiment_environment
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -52,6 +52,7 @@ def check_prompt_length_and_omit_features_if_necessary(prompt: ChatPromptTemplat
                       should_run is True if the model should run, False otherwise
     """
     if num_tokens_from_prompt(prompt, prompt_input) <= max_input_tokens:
+        # Full prompt fits into LLM context => should run with full prompt
         return prompt_input, True
 
     omitted_features = []
@@ -114,7 +115,13 @@ def get_chat_prompt_with_formatting_instructions(
     return ChatPromptTemplate.from_messages([system_message_prompt, human_message_prompt])
 
 
-async def predict_and_parse(model: BaseLanguageModel, chat_prompt: ChatPromptTemplate, prompt_input: dict, pydantic_object: Type[T]) -> Optional[T]:
+async def predict_and_parse(
+        model: BaseLanguageModel, 
+        chat_prompt: ChatPromptTemplate, 
+        prompt_input: dict, 
+        pydantic_object: Type[T], 
+        tags: Optional[List[str]]
+    ) -> Optional[T]:
     """Predicts an LLM completion using the model and parses the output using the provided Pydantic model
 
     Args:
@@ -122,12 +129,23 @@ async def predict_and_parse(model: BaseLanguageModel, chat_prompt: ChatPromptTem
         chat_prompt (ChatPromptTemplate): Prompt to use
         prompt_input (dict): Input parameters to use for the prompt
         pydantic_object (Type[T]): Pydantic model to parse the output
+        tags (Optional[List[str]]: List of tags to tag the prediction with
 
     Returns:
         Optional[T]: Parsed output, or None if it could not be parsed
     """
+    experiment = get_experiment_environment()
+
+    tags = tags or []
+    if experiment.experiment_id is not None:
+        tags.append(f"experiment-{experiment.experiment_id}")
+    if experiment.module_configuration_id is not None:
+        tags.append(f"module-configuration-{experiment.module_configuration_id}")
+    if experiment.run_id is not None:
+        tags.append(f"run-{experiment.run_id}")
+
     if supports_function_calling(model):
-        chain = create_structured_output_chain(pydantic_object, llm=model, prompt=chat_prompt)
+        chain = create_structured_output_chain(pydantic_object, llm=model, prompt=chat_prompt, tags=tags)
         
         try:
             return await chain.arun(**prompt_input)
@@ -136,7 +154,7 @@ async def predict_and_parse(model: BaseLanguageModel, chat_prompt: ChatPromptTem
             return None
 
     output_parser = PydanticOutputParser(pydantic_object=pydantic_object)
-    chain = LLMChain(llm=model, prompt=chat_prompt, output_parser=output_parser)
+    chain = LLMChain(llm=model, prompt=chat_prompt, output_parser=output_parser, tags=tags)
     try:
         return await chain.arun(**prompt_input)
     except (OutputParserException, ValidationError):

--- a/module_programming_llm/module_programming_llm/split_grading_instructions_by_file.py
+++ b/module_programming_llm/module_programming_llm/split_grading_instructions_by_file.py
@@ -97,7 +97,12 @@ async def split_grading_instructions_by_file(
         model=model, 
         chat_prompt=chat_prompt, 
         prompt_input=prompt_input, 
-        pydantic_object=SplitGradingInstructions
+        pydantic_object=SplitGradingInstructions,
+        tags=[
+            f"exercise-{exercise.id}",
+            f"submission-{submission.id}",
+            "split-grading-instructions-by-file"
+        ]
     )
 
     if debug:

--- a/module_programming_llm/module_programming_llm/split_problem_statement_by_file.py
+++ b/module_programming_llm/module_programming_llm/split_problem_statement_by_file.py
@@ -96,7 +96,12 @@ async def split_problem_statement_by_file(
         model=model, 
         chat_prompt=chat_prompt, 
         prompt_input=prompt_input,
-        pydantic_object=SplitProblemStatement
+        pydantic_object=SplitProblemStatement,
+        tags=[
+            f"exercise-{exercise.id}",
+            f"submission-{submission.id}",
+            "split-problem-statement-by-file"
+        ]
     )
 
     if debug:

--- a/module_text_llm/module_text_llm/generate_suggestions.py
+++ b/module_text_llm/module_text_llm/generate_suggestions.py
@@ -75,7 +75,11 @@ async def generate_suggestions(exercise: Exercise, submission: Submission, confi
         model=model, 
         chat_prompt=chat_prompt, 
         prompt_input=prompt_input, 
-        pydantic_object=AssessmentModel
+        pydantic_object=AssessmentModel,
+        tags=[
+            f"exercise-{exercise.id}",
+            f"submission-{submission.id}",
+        ]
     )
 
     if debug:

--- a/playground/src/components/view_mode/evaluation_mode/conduct_experiment/batch_module_experiment.tsx
+++ b/playground/src/components/view_mode/evaluation_mode/conduct_experiment/batch_module_experiment.tsx
@@ -9,6 +9,7 @@ import { FullScreenHandle } from "react-full-screen";
 import useHealth from "@/hooks/health";
 import useBatchModuleExperiment from "@/hooks/batch_module_experiment";
 import { ModuleProvider } from "@/hooks/module_context";
+import { ExperimentIdentifiersProvider } from "@/hooks/experiment_identifiers_context";
 import { ModuleConfiguration } from "../configure_modules";
 import ModuleExperimentProgress from "./module_experiment_progress";
 import SubmissionDetail from "@/components/details/submission_detail";
@@ -256,12 +257,17 @@ function ConductBatchModuleExperimentWrapped(
   ref: React.Ref<ConductBatchModuleExperimentHandles>
 ) {
   return (
-    <ModuleProvider
-      module={props.moduleConfiguration.moduleAndConfig.module}
-      moduleConfig={props.moduleConfiguration.moduleAndConfig.moduleConfig}
-    >
-      <ConductBatchModuleExperiment {...props} ref={ref} />
-    </ModuleProvider>
+    <ExperimentIdentifiersProvider experimentIdentifiers={{
+      experimentId: props.experiment.id,
+      moduleConfigurationId: props.moduleConfiguration.id,
+    }}>
+      <ModuleProvider
+        module={props.moduleConfiguration.moduleAndConfig.module}
+        moduleConfig={props.moduleConfiguration.moduleAndConfig.moduleConfig}
+      >
+        <ConductBatchModuleExperiment {...props} ref={ref} />
+      </ModuleProvider>
+    </ExperimentIdentifiersProvider>
   );
 }
 

--- a/playground/src/hooks/athena_fetcher.ts
+++ b/playground/src/hooks/athena_fetcher.ts
@@ -3,6 +3,7 @@ import type ModuleResponse from "@/model/module_response";
 import baseUrl from "@/helpers/base_url";
 import { useBaseInfo } from "@/hooks/base_info_context";
 import { useModule } from "@/hooks/module_context";
+import { useExperimentIdentifiers } from "@/hooks/experiment_identifiers_context";
 
 export class AthenaError extends Error {
   status: number;
@@ -37,6 +38,21 @@ export class AthenaError extends Error {
 export function useAthenaFetcher() {
   const { module, moduleConfig } = useModule();
   const { athenaUrl, athenaSecret } = useBaseInfo();  
+  const { experimentId, moduleConfigurationId, runId } = useExperimentIdentifiers();
+
+  const headers: { [key: string]: string } = {};
+  if (moduleConfig) {
+    headers["X-Module-Config"] = JSON.stringify(moduleConfig);
+  }
+  if (experimentId) {
+    headers["X-Experiment-ID"] = experimentId;
+  }
+  if (moduleConfigurationId) {
+    headers["X-Module-Configuration-ID"] = moduleConfigurationId;
+  }
+  if (runId) {
+    headers["X-Run-ID"] = runId;
+  }
 
   return (
     async (moduleRoute: string, body?: any) => {
@@ -50,9 +66,7 @@ export function useAthenaFetcher() {
           headers: {
             "Content-Type": "application/json",
             "Authorization": athenaSecret,
-            ...(moduleConfig && {
-              "X-Module-Config": JSON.stringify(moduleConfig),
-            }),
+            ...headers,
           },
           ...(body && { body: JSON.stringify(body) }),
         }

--- a/playground/src/hooks/experiment_identifiers_context.tsx
+++ b/playground/src/hooks/experiment_identifiers_context.tsx
@@ -1,0 +1,64 @@
+import { ReactNode, createContext, useContext, useState } from "react";
+
+export type ExperimentIdentifiers = {
+  experimentId?: string;
+  moduleConfigurationId?: string;
+  runId?: string;
+};
+
+const ExperimentIdentifiersContext = createContext<{
+  state: ExperimentIdentifiers;
+  setRunId: (runId: string | undefined) => void;
+}>({
+  state: {
+    experimentId: undefined,
+    moduleConfigurationId: undefined,
+    runId: undefined,
+  },
+  setRunId: () => null,
+});
+
+function ExperimentIdentifiersProvider({
+  children,
+  experimentIdentifiers,
+}: {
+  children: ReactNode;
+  experimentIdentifiers: ExperimentIdentifiers;
+}) {
+  const [runId, setRunId] = useState(experimentIdentifiers.runId)
+
+  return (
+    <ExperimentIdentifiersContext.Provider
+      value={{ state: {
+        ...experimentIdentifiers,
+        runId,
+      },
+      setRunId
+    }}
+    >
+      {children}
+    </ExperimentIdentifiersContext.Provider>
+  );
+}
+
+function useExperimentIdentifiers() {
+  const context = useContext(ExperimentIdentifiersContext);
+  if (context == undefined) {
+    return {
+      experimentId: undefined,
+      moduleConfigurationId: undefined,
+      runId: undefined,
+    };
+  }
+  return context.state;
+}
+
+function useExperimentIdentifiersSetRunId() {
+  const context = useContext(ExperimentIdentifiersContext);
+  if (context == undefined) {
+    throw new Error('useExperimentIdentifiersSetRunId must be used within an ExperimentIdentifiersContext');
+  }
+  return context.setRunId;
+}
+
+export { ExperimentIdentifiersProvider, useExperimentIdentifiers, useExperimentIdentifiersSetRunId };


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We want to keep track of token usage and response times of the LLMs, especially during an experiment.

### Description
<!-- Describe your changes in detail -->

- Adds a experiment middleware to Athena
- Get experiment context (if provided) with `get_experiment_environment` within a module
- Tag LLM calls for text and programming modules (`submission-id`, `exercise-id`, `experiment-id`, `module-configuration-id`, `run-id`, and operation)
- Update playground to send experiment context in headers

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

It is difficult to test the correct logging, but I tested it. 

1. Test `module_text_llm` in evaluation mode, it should still generate suggestions
2. Test `module_programming_llm` in evaluation mode, it should still generate suggestions 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

Tags appear automatically in LangSmith if the proper environment is setup:
<img width="1442" alt="Screenshot 2023-10-26 at 10 36 51 1" src="https://github.com/ls1intum/Athena/assets/5898705/688b350c-aca6-43f7-ab5e-5537977fca65">
