### PR TITLE
Fix Git commit error with missing email and name

### DIFF
--- a/athena/athena/helpers/programming/code_repository.py
+++ b/athena/athena/helpers/programming/code_repository.py
@@ -52,6 +52,9 @@ def get_repository(url: str, authorization_secret: Optional[str] = None) -> Repo
         repo_zip.extractall(cache_dir_path)
         if not (cache_dir_path / ".git").exists():
             repo = Repo.init(cache_dir_path, initial_branch='main')
+            # Config username and email to prevent Git errors
+            repo.config_writer().set_value("user", "name", "athena").release()
+            repo.config_writer().set_value("user", "email", "doesnotexist.athena@cit.tum.de").release()
             repo.git.add(all=True, force=True)
             repo.git.commit('-m', 'Initial commit')
 


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When testing the programming LLM on the test server, I get this error message:
```
athena-module_programming_llm-1       | git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
athena-module_programming_llm-1       |   cmdline: git commit -m Initial commit
athena-module_programming_llm-1       |   stderr: 'Author identity unknown
athena-module_programming_llm-1       |
athena-module_programming_llm-1       |
athena-module_programming_llm-1       | *** Please tell me who you are.
```

### Description
<!-- Describe your changes in detail -->
Added author identity to the initial Git commit we make to prevent this error.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Make a request to the programming LLM module in the playground in evaluation mode.