### PR TITLE
Fix send training feedback getting stuck

### DIFF
--- a/playground/src/hooks/batch_module_experiment.ts
+++ b/playground/src/hooks/batch_module_experiment.ts
@@ -161,11 +161,11 @@ export default function useBatchModuleExperiment(experiment: Experiment) {
         (feedback) => feedback.submission_id === submission?.id
       );
       
-      try {  
-        console.log(
-          `Sending training feedbacks to Athena... (${num}/${submissionsToSend.length})`
-        );
+      console.log(
+        `Sending training feedbacks to Athena... (${num}/${submissionsToSend.length})`
+      );
 
+      try {  
         if (submissionFeedbacks.length > 0) {
           await sendFeedbacks.mutateAsync({
             exercise: experiment.exercise,

--- a/playground/src/hooks/batch_module_experiment.ts
+++ b/playground/src/hooks/batch_module_experiment.ts
@@ -160,22 +160,21 @@ export default function useBatchModuleExperiment(experiment: Experiment) {
       const submissionFeedbacks = experiment.tutorFeedbacks.filter(
         (feedback) => feedback.submission_id === submission?.id
       );
-      if (submissionFeedbacks.length === 0) {
-        continue;
-      }
+      
+      try {  
+        console.log(
+          `Sending training feedbacks to Athena... (${num}/${submissionsToSend.length})`
+        );
 
-      console.log(
-        `Sending training feedbacks to Athena... (${num}/${submissionsToSend.length})`
-      );
-
-      try {
-        await sendFeedbacks.mutateAsync({
-          exercise: experiment.exercise,
-          submission,
-          feedbacks: submissionFeedbacks,
-        });
-        if (!isMounted.current) {
-          return;
+        if (submissionFeedbacks.length > 0) {
+          await sendFeedbacks.mutateAsync({
+            exercise: experiment.exercise,
+            submission,
+            feedbacks: submissionFeedbacks,
+          });
+          if (!isMounted.current) {
+            return;
+          }
         }
 
         setData((prevState) => ({


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If there is no training feedback for a submission to send it is getting stuck:
![screenshot-2023-10-27_002042_480](https://github.com/ls1intum/Athena/assets/5898705/89d12c30-d2e2-48ac-ac1f-f70b3a102998)

### Description
<!-- Describe your changes in detail -->

Fix issue by adding the submission to the sent submissions (for training feedback).

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Test evaluation mode with `module_text_llm` with the "What is your name?" example exercise

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

<img width="646" alt="Screenshot 2023-10-27 at 01 23 18" src="https://github.com/ls1intum/Athena/assets/5898705/5008cb4b-7872-449a-87c5-8a92f6a3dedb">
