### PR TITLE
Fix OpenAI API key error when unset

### DIFF
--- a/module_programming_llm/module_programming_llm/helpers/models/openai.py
+++ b/module_programming_llm/module_programming_llm/helpers/models/openai.py
@@ -28,6 +28,9 @@ AZURE_OPENAI_PREFIX = "azure_openai_"
 # the models to azure that we want to use.                              #
 #########################################################################
 
+# Prevent LangChain error, we will set the key later
+os.environ["OPENAI_API_KEY"] = ""
+
 def _wrap(old: Any, new: Any) -> Callable:
     def repl(*args: Any, **kwargs: Any) -> Any:
         new(args[0])  # args[0] is self

--- a/module_text_llm/module_text_llm/helpers/models/openai.py
+++ b/module_text_llm/module_text_llm/helpers/models/openai.py
@@ -28,6 +28,9 @@ AZURE_OPENAI_PREFIX = "azure_openai_"
 # the models to azure that we want to use.                              #
 #########################################################################
 
+# Prevent LangChain error, we will set the key later
+os.environ["OPENAI_API_KEY"] = ""
+
 def _wrap(old: Any, new: Any) -> Callable:
     def repl(*args: Any, **kwargs: Any) -> Any:
         new(args[0])  # args[0] is self


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When `OPENAI_API_KEY` is unset LangChain throws an error.

![image (2)](https://github.com/ls1intum/Athena/assets/5898705/18029205-67b9-4a16-91b2-da95ef0e19c5)

### Description
<!-- Describe your changes in detail -->

Set `OPENAI_API_KEY=""` programatically so it does not throw.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Remove `OPENAI_API_KEY` from environment and run a LLM module feedback generation request.