### PR TITLE
Remove the CoFee MongoDB database

### DIFF
--- a/docker-compose.cofee.yml
+++ b/docker-compose.cofee.yml
@@ -28,7 +28,7 @@ services:
   # http://localhost/getTask
   # http://localhost/sendTaskResult
   load-balancer:
-    image: ghcr.io/ls1intum/athena/load-balancer
+    image: ghcr.io/ls1intum/athena/load-balancer:remove-tracking-and-feedback-consistency
     container_name: cofee-load-balancer
     restart: unless-stopped
     expose:
@@ -47,7 +47,7 @@ services:
       - traefik.http.routers.balancer.entrypoints=web
 
   segmentation:
-    image: ghcr.io/ls1intum/athena/segmentation
+    image: ghcr.io/ls1intum/athena/segmentation:remove-tracking-and-feedback-consistency
     container_name: cofee-segmentation
     restart: unless-stopped
     depends_on:
@@ -64,12 +64,11 @@ services:
   # http://localhost/upload
   # http://localhost/feedback_consistency
   embedding:
-    image: ghcr.io/ls1intum/athena/embedding
+    image: ghcr.io/ls1intum/athena/embedding:remove-tracking-and-feedback-consistency
     container_name: cofee-embedding
     restart: unless-stopped
     depends_on:
       - load-balancer
-      - database
     expose:
        - 8000
     env_file:
@@ -82,12 +81,11 @@ services:
       - traefik.http.services.cofee-embedding.loadbalancer.server.port=8000 # set service name this way
 
   clustering:
-    image: ghcr.io/ls1intum/athena/clustering
+    image: ghcr.io/ls1intum/athena/clustering:remove-tracking-and-feedback-consistency
     container_name: cofee-clustering
     restart: unless-stopped
     depends_on:
       - load-balancer
-      - database
     expose:
        - 8000
     env_file:
@@ -96,16 +94,3 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.services.cofee-clustering.loadbalancer.server.port=8000 # set service name this way
-
-  database:
-    image: mongo:latest
-    container_name: cofee-mongodb
-    restart: unless-stopped
-    expose:
-      - 27017
-    env_file:
-      - ${ATHENA_ENV_DIR:-./env_example}/cofee.env
-    volumes:
-      - ./module_text_cofee/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
-      - ./data/cofee_db:/data/db
-    command: --quiet > /dev/null

--- a/docker-compose.cofee.yml
+++ b/docker-compose.cofee.yml
@@ -28,7 +28,7 @@ services:
   # http://localhost/getTask
   # http://localhost/sendTaskResult
   load-balancer:
-    image: ghcr.io/ls1intum/athena/load-balancer:remove-tracking-and-feedback-consistency
+    image: ghcr.io/ls1intum/athena/load-balancer:ff6c4d0
     container_name: cofee-load-balancer
     restart: unless-stopped
     expose:
@@ -47,7 +47,7 @@ services:
       - traefik.http.routers.balancer.entrypoints=web
 
   segmentation:
-    image: ghcr.io/ls1intum/athena/segmentation:remove-tracking-and-feedback-consistency
+    image: ghcr.io/ls1intum/athena/segmentation:ff6c4d0
     container_name: cofee-segmentation
     restart: unless-stopped
     depends_on:
@@ -64,7 +64,7 @@ services:
   # http://localhost/upload
   # http://localhost/feedback_consistency
   embedding:
-    image: ghcr.io/ls1intum/athena/embedding:remove-tracking-and-feedback-consistency
+    image: ghcr.io/ls1intum/athena/embedding:ff6c4d0
     container_name: cofee-embedding
     restart: unless-stopped
     depends_on:
@@ -81,7 +81,7 @@ services:
       - traefik.http.services.cofee-embedding.loadbalancer.server.port=8000 # set service name this way
 
   clustering:
-    image: ghcr.io/ls1intum/athena/clustering:remove-tracking-and-feedback-consistency
+    image: ghcr.io/ls1intum/athena/clustering:ff6c4d0
     container_name: cofee-clustering
     restart: unless-stopped
     depends_on:

--- a/env_example/cofee.env
+++ b/env_example/cofee.env
@@ -10,9 +10,6 @@ LOAD_BALANCER_CONFIG_FILE_PATH=/config/node_config.docker.yml
 
 # shared worker variables
 AUTHORIZATION_SECRET=YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=
-DATABASE_HOST=database
-DATABASE_PORT=27017
-DATABASE_NAME=athene_db
 BALANCER_QUEUE_FREQUENCY=600
 BALANCER_GETTASK_URL=http://load-balancer:8000/getTask
 BALANCER_SENDRESULT_URL=http://load-balancer:8000/sendTaskResult
@@ -21,18 +18,4 @@ BALANCER_SENDRESULT_URL=http://load-balancer:8000/sendTaskResult
 
 # embedding variables
 EMBEDDING_CLOUD_CONFIG_PATH=./embedding/src/cloud/config.py
-EMBEDDING_DATABASE_USER=embedding
-EMBEDDING_DATABASE_PWD=embedding_password
 EMBEDDING_CHUNK_SIZE=50
-
-# clustering variables
-CLUSTERING_DATABASE_USER=embedding
-CLUSTERING_DATABASE_PWD=embedding_password
-
-# tracking variables
-TRACKING_DATABASE_USER=tracking
-TRACKING_DATABASE_PWD=tracking_password
-
-# database variables
-DATABASE_ROOT_USERNAME=root
-DATABASE_ROOT_PASSWORD=root_password

--- a/module_text_cofee/module_text_cofee/adapter.py
+++ b/module_text_cofee/module_text_cofee/adapter.py
@@ -59,7 +59,11 @@ def send_submissions(exercise: Exercise, submissions: List[Submission]):
         # TODO: remove this again:
         verify=False,  # Ignore SSL errors for now, because athenetest1-01 has an invalid certificate
     )
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logger.error("Failed to send submissions to CoFee: %s", e)
+        raise e
     logger.info("Submissions sent to CoFee")
 
 

--- a/module_text_cofee/module_text_cofee/adapter.py
+++ b/module_text_cofee/module_text_cofee/adapter.py
@@ -36,6 +36,7 @@ def get_cofee_url() -> str:
 def send_submissions(exercise: Exercise, submissions: List[Submission]):
     """Send submissions to old Athena-CoFee server."""
     logger.info("Sending %d submissions to CoFee", len(submissions))
+    logger.debug("Sending to %s with submissions: %s", get_cofee_url(), submissions)
     module_url = os.environ.get("MODULE_URL", f"http://localhost:{get_module_config().port}")
     resp = requests.post(
         f"{get_cofee_url()}/submit",


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When https://github.com/ls1intum/Athena-CoFee/pull/83 is merged, we don't need the config for the CoFee MongoDB anymore.

### Description
<!-- Describe your changes in detail -->
Remove the MongoDB Docker service.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Test is feedback suggestion generation still works for CoFee.

> **Note**
> This PR hardcodes the docker images from https://github.com/ls1intum/Athena-CoFee/pull/83. We should remove the specific tags before merging.