### PR TITLE
`CoFee`: Prefix CoFee database table names

### DIFF
--- a/module_text_cofee/module_text_cofee/models/db_text_block.py
+++ b/module_text_cofee/module_text_cofee/models/db_text_block.py
@@ -18,7 +18,7 @@ class DBTextBlock(Base):
 
     # foreign keys
     submission_id = Column(Integer, ForeignKey("text_submissions.id"))  # FK to athena-native table
-    cluster_id = Column(Integer, ForeignKey("text_clusters.id"))  # FK to custom table
+    cluster_id = Column(Integer, ForeignKey("cofee_text_clusters.id"))  # FK to custom table
 
     submission = relationship("DBTextSubmission")
     cluster = relationship("DBTextCluster", back_populates="blocks")

--- a/module_text_cofee/module_text_cofee/models/db_text_block.py
+++ b/module_text_cofee/module_text_cofee/models/db_text_block.py
@@ -8,7 +8,7 @@ from athena.logger import logger
 
 
 class DBTextBlock(Base):
-    __tablename__ = "text_blocks"
+    __tablename__ = "cofee_text_blocks"
 
     id = Column(String, primary_key=True, index=True)  # type: ignore
     text = Column(String)  # type: ignore

--- a/module_text_cofee/module_text_cofee/models/db_text_cluster.py
+++ b/module_text_cofee/module_text_cofee/models/db_text_cluster.py
@@ -9,7 +9,7 @@ from athena.logger import logger
 
 
 class DBTextCluster(Base):
-    __tablename__ = "text_clusters"
+    __tablename__ = "cofee_text_clusters"
 
     id: int = Column(Integer, primary_key=True, index=True)  # type: ignore
     probabilities: bytes = Column(LargeBinary)  # type: ignore


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When using one database for all modules, it is difficult to distinguish the CoFee-related database tables from the default ones:
![image](https://github.com/ls1intum/Athena/assets/9006596/ae7f7de7-c180-40c6-9538-0ff51c9e412a)

### Description
<!-- Describe your changes in detail -->
Prefix the tables related to CoFee with `cofee_`: 
![screenshot-2023-11-20_002111](https://github.com/ls1intum/Athena/assets/9006596/f3f758be-5a6a-49a9-bfba-ca2cc9d27044)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Test the CoFee module. It's a bit difficult right now because it does not seem to function in the Playground somehow. I'm investigating this.