### PR TITLE
`Documentation`: Add note about PostgreSQL dependency

### DIFF
--- a/docs/setup/install.rst
+++ b/docs/setup/install.rst
@@ -16,4 +16,8 @@ You'll have to do this once in the following folders to set up the project:
 - ``athena``
 - ``module_*`` (for each module)
 
+.. note::
+    | The ``psycopg2`` module needs PostgreSQL to be installed on your system. You can find installation instructions on the `PostgreSQL website <https://www.postgresql.org/download/>`_.
+    | Example to install it on MacOS: ``brew install postgresql``
+
 You can find more information about Poetry in the `Poetry documentation <https://python-poetry.org/docs/>`_.


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When running `poetry install` without PostgreSQL installed, it fails with a weird error message.
![screenshot-2023-11-20_002117](https://github.com/ls1intum/Athena/assets/9006596/56de1644-b11c-4845-9543-b5b12c389863)

### Description
<!-- Describe your changes in detail -->
Add documentation about that dependency.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
![screenshot-2023-11-20_002118](https://github.com/ls1intum/Athena/assets/9006596/863551d8-4315-4d51-bf1f-554a001d059c)
