### PR TITLE
`ModelingLLM`: Update ID concatenation and tag prefixing logic

### DIFF
--- a/module_modelling_llm/module_modelling_llm/helpers/serializers/bpmn_serializer.py
+++ b/module_modelling_llm/module_modelling_llm/helpers/serializers/bpmn_serializer.py
@@ -103,7 +103,7 @@ class IDShortener:
             prefix = "id"
 
         if id not in self.id_map:
-            self.id_map[id] = f"{prefix}{'-' if prefix else ''}{self.id_counter}"
+            self.id_map[id] = f"{prefix}{'_' if prefix else ''}{self.id_counter}"
             self.id_counter += 1
 
         return self.id_map[id]
@@ -232,7 +232,7 @@ class BPMNSerializer:
         :param tag: The prefixed tag
         :param prefix: The prefix to prepend
         """
-        return f"{prefix}{':' if prefix else ''}{tag}"
+        return f"{prefix if prefix else ''}{':' if prefix else ''}{tag}"
 
     def __shorten_id(self, element_id: str, prefix: Optional[str] = None) -> str:
         """


### PR DESCRIPTION
### Motivation and Context
This PR adds small fixes for the ID shortening logic for BPMN diagrams as well as the XML-tag prefixing logic.

### Description
IDs and their prefix now concatenated with an underscore rather with a dash as intended.

Currently, when providing None as prefix, tags are generated as "None:tag_name" which is not the intended behavior. This PR resolves this issue by ensuring None-prefixes are omitted entirely.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->