### PR TITLE
`Chore`: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: 🐛 Bug Report
 description: Something's not working in Athena? File a bug report!
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,80 @@
+name: Bug Report
+description: Something's not working in Athena? File a bug report!
+labels: ["bug"]
+body:
+- type: markdown
+  attributes:
+    value: Thank you for taking the time to fill out this bug report! Please provide as much detail as possible to help us identify and fix the problem.
+- type: textarea
+  attributes:
+    label: Please describe the bug
+    description: A clear and concise description of what the bug is.
+    placeholder: What has gone wrong? Please be as specific as possible.
+  validations:
+      required: true
+- type: textarea
+  attributes:
+    label: To Reproduce
+    description: "Steps to reproduce the behavior:"
+    value: |
+      1. Go to '...'
+      2. Click on '...'
+      3. Scroll down to '...'
+      4. See error
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: A clear and concise description of what you expected to happen.
+    placeholder: What did you expect to happen instead?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Screenshots
+    description: If applicable, add screenshots to help explain your problem.
+- type: dropdown
+  attributes:
+    label: What module is this bug related to?
+    multiple: true
+    options:
+      - Assessment Module Manager
+      - Modeling LLM
+      - Programming AST
+      - Programming Code Embedding
+      - Programming LLM
+      - Programming ThemisML
+      - Text CoFee
+      - Text LLM
+      - Playground
+      - Other (specify in "Additional context")
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: What browsers are you seeing the problem on?
+    multiple: true
+    options:
+      - Chrome
+      - Safari
+      - Microsoft Edge
+      - Firefox
+      - Other (specify in "Additional context")
+- type: input
+  attributes:
+    label: Operating System
+    description: The operating system you're using. E.g. Windows 11, macOS Sonoma, Ubuntu 20.04, etc.
+- type: textarea
+  attributes:
+    label: Additional context
+    description: Add any other context to the problem here.
+- type: textarea
+  id: logs
+  attributes:
+    label: Relevant log output
+    description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+    render: shell
+- type: markdown
+  attributes:
+    value: Thanks for completing our form! Please click the "Submit new issue" button below to submit your bug report.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: 🚀 Feature Request
 description: Something's missing in Athena? Suggest a new feature!
 labels: [feature]
 body:
@@ -12,8 +12,8 @@ body:
     placeholder: "For example: I'm always frustrated when [...] or I wish I could [...]."
 - type: textarea
   attributes:
-    label: Describe the solution you want
-    description: You can also upload additional material such as mock-ups, diagrams or sketches to support your idea.
+    label: Describe the solution you'd like
+    description: Feel free to upload additional material such as mock-ups, diagrams, or sketches to support your idea.
   validations:
       required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,26 @@
+name: Feature Request
+description: Something's missing in Athena? Suggest a new feature!
+labels: [feature]
+body:
+- type: markdown
+  attributes:
+    value: Thank you for taking the time to submit a feature request! Please describe your request in detail so that we can understand your ideas.
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem?
+    description: A clear and concise description of what the problem is.
+    placeholder: "For example: I'm always frustrated when [...] or I wish I could [...]."
+- type: textarea
+  attributes:
+    label: Describe the solution you want
+    description: You can also upload additional material such as mock-ups, diagrams or sketches to support your idea.
+  validations:
+      required: true
+- type: textarea
+  attributes:
+    label: Describe the alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+- type: textarea
+  attributes:
+    label: Additional context
+    description: Add any additional context or screenshots here.


### PR DESCRIPTION
## Motivation and Context
This project is missing issue templates for bugs/features/custom. Also see issue #287.

## Description
Added issue templates for bug reports and feature requests. Also enabled blank issues, in case an issue does not fit into these categories.

## Steps for Testing
- Please look through the templates and add your feedback

You can see a preview of the issue templates when you go to [bug report](https://github.com/ls1intum/Athena/blob/chore/issue-templates/.github/ISSUE_TEMPLATE/bug-report.yml) and [feature request](https://github.com/ls1intum/Athena/blob/chore/issue-templates/.github/ISSUE_TEMPLATE/feature-request.yml). Note that the description (grey text below the text fields) will appear above the text fields when used as issue templates, not below them.
