### PR TITLE
Update documentation for deployments

### DIFF
--- a/docs/administration_of_deployments/configuration.rst
+++ b/docs/administration_of_deployments/configuration.rst
@@ -1,0 +1,9 @@
+Configuration
+===========================================
+
+Athena can serve requests from multiple LM systems. It uses a custom HTTP header ``X-Server-URL`` to identify the origin of each request. To prevent unauthorized use of resources, the admin must whitelist all supported deployments. This configuration is done in the ``assessment_module_manager/deployments.ini`` file or the corresponding Docker analog for server deployments using Docker images.
+
+For each listed deployment, the admin must define a corresponding secret in the environment variable ``LMS_DEPLOYMENT_NAME_SECRET`` (replace DEPLOYMENT_NAME with the name from the .ini file) of the ``assessment_module_manager``.
+Please note: Playground counts as an LMS and needs its own record.
+
+This configuration does not exclude or replace inter-module authentication; Athena still requires keys between modules and the assessment module manager.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,3 +66,10 @@ Athena will use the information it is given and provide the automatic suggestion
 
     athena_package/storage
     athena_package/helpers
+
+.. toctree::
+    :caption: Administration of Deployments
+    :includehidden:
+    :maxdepth: 1
+
+    administration_of_deployments/configuration

--- a/env_example/assessment_module_manager.env
+++ b/env_example/assessment_module_manager.env
@@ -1,5 +1,4 @@
 PRODUCTION=1
-SECRET=abcdef12345
 
 # module secrets, same as in the module env files
 MODULE_EXAMPLE_SECRET=12345abcdef
@@ -9,7 +8,7 @@ MODULE_TEXT_COFEE_SECRET=12345abcdef
 MODULE_PROGRAMMING_THEMISML_SECRET=12345abcdef
 
 ################################################################
-# LMS Deployments                                          #
+# LMS Deployments                                              #
 ################################################################
 # the deployment name should correspond to the name in deployments.ini
 LMS_DEPLOYMENT_NAME_SECRET=12345abcdef


### PR DESCRIPTION
### Motivation and Context
The process of Athena deployments changed slightly, but the documentation is not up-to-date. This PR closes the gap.

### Description
I created a new section, `configuration` in the docs module. I described how to handle deployments there.

### Steps for Testing
Just check the built documentation.

### Screenshots
![image](https://github.com/user-attachments/assets/be9494f9-0bef-484b-87df-c9ecb64bf00d)
