### PR TITLE
`Playground`: UI Improvements to inline feedback

### DIFF
--- a/playground/src/components/details/editor/inline_feedback.tsx
+++ b/playground/src/components/details/editor/inline_feedback.tsx
@@ -190,7 +190,7 @@ export default function InlineFeedback({
         ) : (
           <div
             className={twMerge(
-              "font-medium rounded px-2.5 py-0.5 mt-2",
+              "font-medium rounded px-2.5 py-0.5",
               feedback.credits < 0
                 ? "bg-red-100 text-red-800"
                 : feedback.credits > 0
@@ -210,12 +210,19 @@ export default function InlineFeedback({
                 placeholder="Title..."
                 onChange={(e) => setTitle(e.target.value)}
               />
-            ) : (
+            ) : feedback.title && (
               <span className="font-semibold">
-                {feedback.title ? feedback.title : <i>Missing title</i>}
+                {feedback.title}
               </span>
             )}
           </div>
+          {feedback.structured_grading_instruction?.feedback && (
+            <div className="w-full text-orange-800 rounded px-2 py-0.5 bg-orange-100">
+              <span className="whitespace-pre-wrap">
+                {feedback.structured_grading_instruction.feedback}
+              </span>
+            </div>
+          )}
           <div>
             {isEditing && onFeedbackChange ? (
               <TextareaAutosize
@@ -224,12 +231,10 @@ export default function InlineFeedback({
                 placeholder="Description..."
                 onChange={(e) => setDescription(e.target.value)}
               />
-            ) : feedback.description ? (
+            ) : feedback.description && (
               <span className="whitespace-pre-wrap">
                 {feedback.description}
               </span>
-            ) : (
-              <i>Missing description</i>
             )}
           </div>
         </div>

--- a/playground/src/hooks/playground/feedbacks.ts
+++ b/playground/src/hooks/playground/feedbacks.ts
@@ -15,7 +15,14 @@ export async function fetchFeedbacks(
   const response = await fetch(
     `${baseUrl}/api/data/${dataMode}/${exercise ? `exercise/${exercise.id}/` : ""}feedbacks`
   );
-  const feedbacks = await response.json() as Feedback[];
+
+  let feedbacks = await response.json() as Feedback[];
+  for (const feedback of feedbacks) {
+    if (feedback.structured_grading_instruction_id) {
+      feedback.structured_grading_instruction = exercise?.grading_criteria?.flatMap((criteria) => criteria.structured_grading_instructions).find((instruction) => instruction.id === feedback.structured_grading_instruction_id);
+    }
+  }
+
   if (submission) {
     return feedbacks.filter((feedback) => feedback.submission_id === submission.id);
   }

--- a/playground/src/model/feedback.ts
+++ b/playground/src/model/feedback.ts
@@ -1,5 +1,5 @@
 import type { IRange, editor } from "monaco-editor";
-import type { ExerciseType } from "./exercise";
+import type { ExerciseType, StructuredGradingInstruction } from "./exercise";
 import type { Submission } from "./submission";
 
 type FeedbackBase = {
@@ -11,6 +11,7 @@ type FeedbackBase = {
   exercise_id: number;
   submission_id: number;
   structured_grading_instruction_id?: number;
+  structured_grading_instruction?: StructuredGradingInstruction; // Playground only
   isSuggestion?: boolean; // Playground only
   isNew?: boolean; // Playground only
   isChanged?: boolean; // Playground only


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With the upcoming expert evaluation in mind, we want to improve the UX for reading submissions and their inline feedback.

### Description
<!-- Describe your changes in detail -->
- **Enhanced Display for Missing Information**: Titles and descriptions that are missing will now be hidden instead of displaying placeholder text like “missing title” or “missing description.” This ensures a cleaner and more professional appearance.
- **Improved Feedback Visibility**: Feedback from structured grading instructions is now included directly within the feedback item itself. This is in addition to the existing feedback ID displayed in the top right corner, providing clearer and more detailed feedback for users.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
- Go into evaluation mode. 

In Evaluation mode:
- Select a text exercise (preferably with structured grading instructions)
- At the bottom of the evaluation mode panel is a dropdown. You can view the submissions with inline feedbacks there.


### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Athena/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Athena/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->

After (Manual feedback)
<img width="558" alt="Bildschirmfoto 2024-08-12 um 15 52 31" src="https://github.com/user-attachments/assets/09579a56-0b8b-48f6-9b19-94b56f4e6de5">

Before (Manual feedback)
<img width="558" alt="Bildschirmfoto 2024-08-12 um 15 53 37" src="https://github.com/user-attachments/assets/68347e8c-c0f3-4156-94d4-4d3349b1356e">

---

After (referenced grading instruction)
<img width="558" alt="Bildschirmfoto 2024-08-12 um 15 52 43" src="https://github.com/user-attachments/assets/edb2e509-23eb-4740-a171-f0fd9c33828c">

Before (referenced grading instruction)
<img width="558" alt="Bildschirmfoto 2024-08-12 um 15 53 44" src="https://github.com/user-attachments/assets/aa8c9463-6881-4807-b7d3-7bf817746c82">

---

After (referenced grading instruction + manual feedback)
<img width="558" alt="Bildschirmfoto 2024-08-12 um 15 53 02" src="https://github.com/user-attachments/assets/07ced916-8308-4b27-8d8b-0b2ee2aa2bbd">

Before (referenced grading instruction + manual feedback)
<img width="558" alt="Bildschirmfoto 2024-08-12 um 15 54 18" src="https://github.com/user-attachments/assets/4dbb3bd3-ea5d-4cb9-8058-17ac4115a2df">


