### PR TITLE
`Quickfix:` Retry on erros in llm_core

### DIFF
--- a/llm_core/llm_core/utils/predict_and_parse.py
+++ b/llm_core/llm_core/utils/predict_and_parse.py
@@ -58,9 +58,15 @@ async def predict_and_parse(
     if (use_function_calling):
         structured_output_llm = model.with_structured_output(pydantic_object)
         chain = chat_prompt | structured_output_llm
+
+        chain_with_retries = chain.with_retry(
+            retry_if_exception_type=(ValidationError, ValueError),
+            wait_exponential_jitter=True,
+            stop_after_attempt=3
+        )
         
         try:
-            result = await chain.ainvoke(prompt_input, config={"tags": tags})
+            result = await chain_with_retries.ainvoke(prompt_input, config={"tags": tags})
             
             if isinstance(result, pydantic_object):
                 return result


### PR DESCRIPTION
### Motivation and Context
I added retry mechanism in the llm_core module  to improve system resilience against temporary LLM call failures. This helps prevent disruptions due to transient issues and reduces the need for manual re-execution.

### Description
Integrated LangChain’s with_retry to automatically retry failed LLM calls.
Configured retry parameters.

### Steps for Testing
Just deploy and request feedback

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.
> Green = Currently available, Red = Currently locked
> Click on the badges to get to the test servers.

[![](https://byob.yarr.is/ls1intum/Athena/athena-test1)](https://athena-test1.ase.cit.tum.de)
[![](https://byob.yarr.is/ls1intum/Athena/athena-test2)](https://athena-test2.ase.cit.tum.de)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI of the playground etc. -->
